### PR TITLE
Changed SaveBindings call to be Classic compatible.

### DIFF
--- a/vUI/Elements/ActionBars/KeyBinding.lua
+++ b/vUI/Elements/ActionBars/KeyBinding.lua
@@ -150,7 +150,7 @@ local ToggleBindingMode = function()
 end
 
 local OnAccept = function()
-	SaveBindings(GetCurrentBindingSet())
+	AttemptToSaveBindings(GetCurrentBindingSet())
 	
 	GUI:GetWidgetByWindow(Language["Action Bars"], "discard"):Disable()
 	GUI:GetWidgetByWindow(Language["Action Bars"], "save"):Disable()


### PR DESCRIPTION
Saving changed bindings doesn't do anything, even the confirmation dialog doesn't close.

According to https://wow.gamepedia.com/API_SaveBindings Classic uses AttemptToSaveBindings rather than SaveBindings.